### PR TITLE
gh formula fixes

### DIFF
--- a/Formula/gh.rb
+++ b/Formula/gh.rb
@@ -1,12 +1,27 @@
 class Gh < Formula
   desc "GitHub CLI"
-  url "https://github.com/github/homebrew-gh/releases/download/v0.0.195/gh-cli_0.0.195_darwin_amd64.tar.gz"
-  sha256 "82f8c50415d14851d3fb1a800ffd047f181880deb5450acd67bc7594fa2a19ea"
+  homepage "https://github.com/github/gh-cli"
+  version "0.0.195"
+
+  if OS.mac?
+    url "https://github.com/github/homebrew-gh/releases/download/v0.0.195/gh-cli_0.0.195_darwin_amd64.tar.gz"
+    sha256 "82f8c50415d14851d3fb1a800ffd047f181880deb5450acd67bc7594fa2a19ea"
+  elsif OS.linux?
+    # TODO
+  end
+
+  head do
+    url "https://github.com/github/gh-cli.git", :branch => "prototype"
+    depends_on "go"
+  end
 
   bottle :unneeded
 
   def install
-    bin.install "gh"
+    system "make" if build.head?
+    bin.install File.exist?("bin/gh") ? "bin/gh" : "gh"
+    (bash_completion/"gh.sh").write `#{bin}/gh completion -s bash`
+    (zsh_completion/"_gh").write `#{bin}/gh completion -s zsh`
   end
 
   test do

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Homebrew tap for GitHub CLI
 
-First-time:
+Installation:
 
 ```sh
-brew install github/homebrew-gh/gh
+brew install github/gh/gh
 ```
 
 That's it. You are now ready to use `gh`. 🥳
@@ -21,10 +21,19 @@ Available Commands:
   pr          Work with pull requests
 ```
 
-To stay up to date with `gh` development:
+Thank you for trying out GitHub CLI! 🌟
 
-```sh
-brew upgrade gh
+### Development version (restricted access)
+
+You can get access to features that are not yet in the stable release by
+building the development version:
+
+```
+brew install github/gh/gh --HEAD
 ```
 
-Thank you for testing GitHub CLI! 🌟
+To upgrade it:
+
+```
+brew upgrade gh --fetch-HEAD
+```


### PR DESCRIPTION
- keep `head` spec to allow `--HEAD` installs from "prototype" git branch
- explicitly specify `version` because Homebrew failed to infer version number from `url`
- bring back bash/zsh completion support because the feature exists both in latest master and prototype, it just needs a newer tag
- add TODO block for future Linux release

Ref. #2, reverts 2f76da9a4b3974934fc3f3b06d4bd41744cc28a9